### PR TITLE
add 'customProps' for extra button props (like aria-label)

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -23,12 +23,14 @@ export default class Base extends React.Component {
 		const formattedWidth = this.formattedSize(width)
 		const formattedHeight = this.formattedSize(height)
 
+		const customProps = this.props.customProps || {}
+
 		const classes = [typeClassName, 'Burger']
 		if(active) classes.push('BurgerActive')
 		if(className) classes.push(className)
 
 		return (
-			<button className={classes.join(' ')} onClick={onClick}>
+			<button className={classes.join(' ')} onClick={onClick} {...customProps}>
 				<div className='BurgerBox'>
 					<div className='BurgerInner' />
 				</div>


### PR DESCRIPTION
for accessibility (chrome audit) purposes I'd like to add the 'aria-label' prop to the button, I added customProps where you can a provide extra props for the button